### PR TITLE
fix(configs): repair subagents-once contract

### DIFF
--- a/configs/pi/.config/pi/agent/extensions/subagent/config.json
+++ b/configs/pi/.config/pi/agent/extensions/subagent/config.json
@@ -8,7 +8,6 @@
   "missions": {
     "enabled": false
   },
-  "maxSubagentSpawnsPerSession": 6,
   "maxSubagentDepth": 1,
   "artifactDir": "session"
 }

--- a/configs/pi/.config/pi/agent/extensions/subagents-once/README.md
+++ b/configs/pi/.config/pi/agent/extensions/subagents-once/README.md
@@ -5,9 +5,9 @@ short-lived. Subagent tools are unavailable to the parent model by default.
 Running `/subagents-once` exposes `oracle` and `reviewer` for one parent run,
 with at most one child call total.
 
-The extension delegates through the public `pi-subagents` version 2 event
-contract. `pi-subagents` remains responsible for child discovery, model and
-thinking defaults, session creation, progress, cancellation, and usage
+The extension delegates through the public `pi-subagents` structured owned-leaf
+event contract. `pi-subagents` remains responsible for child discovery, model
+and thinking defaults, session creation, progress, cancellation, and usage
 accounting.
 
 ## Requirements
@@ -21,8 +21,9 @@ The repository configuration currently:
 - installs `git:github.com/nicobailon/pi-subagents`;
 - filters out the package's skills and prompt templates;
 - configures `oracle` with forked context;
-- configures `reviewer` with fresh context;
-- keeps unused builtin child roles disabled; and
+- configures `reviewer` with fresh context and no direct `edit` or `write` tools;
+- keeps unused builtin child roles disabled;
+- leaves the backend session spawn count unlimited; and
 - configures foreground execution and session-scoped artifacts in
   `../subagent/config.json`.
 
@@ -178,7 +179,7 @@ The extension enforces the objective boundaries in code:
 - execution is foreground-only and always starts a new child;
 - progress and bounded metadata are returned to the parent;
 - nested model usage contributes to Pi's session totals; and
-- cancellation uses the full version 2 request identity.
+- cancellation uses the full request, owner-run, and node identity.
 
 Semantic value remains the parent's judgment. The extension does not attempt to
 infer whether the three gates passed from keywords in the task.
@@ -221,6 +222,14 @@ PI_SUBAGENTS_ONCE_SELF_TEST=1 \
   pi --no-session --no-extensions \
   -e configs/pi/.config/pi/agent/extensions/subagents-once/index.ts \
   --list-models >/dev/null
+```
+
+Check the request shape and resolved reviewer tool allowlist against the
+currently installed `pi-subagents`:
+
+```bash
+node --experimental-strip-types \
+  configs/pi/.config/pi/agent/extensions/subagents-once/contract-test.ts
 ```
 
 For a smoke test:

--- a/configs/pi/.config/pi/agent/extensions/subagents-once/contract-test.ts
+++ b/configs/pi/.config/pi/agent/extensions/subagents-once/contract-test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function main(): Promise<void> {
+  const agentDir = process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".config/pi/agent");
+  const packageDir = join(agentDir, "git/github.com/nicobailon/pi-subagents");
+  const delegation = await import(pathToFileURL(join(packageDir, "src/api/delegation.ts")).href);
+  const { resolveSubagentLaunchContract } = await import(
+    pathToFileURL(join(packageDir, "src/api/preflight.ts")).href
+  );
+  const { parseSubagentDelegationRequest } = await import(
+    pathToFileURL(join(packageDir, "src/slash/delegation-request.ts")).href
+  );
+
+  assert.equal(delegation.SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");
+  assert.equal(delegation.SUBAGENT_DELEGATION_UPDATE_EVENT, "prompt-template:subagent:update");
+  assert.equal(delegation.SUBAGENT_DELEGATION_RESPONSE_EVENT, "prompt-template:subagent:response");
+  assert.equal(delegation.SUBAGENT_DELEGATION_CANCEL_EVENT, "prompt-template:subagent:cancel");
+
+  const parsed = parseSubagentDelegationRequest({
+    requestId: "request",
+    ownerRunId: "owner",
+    nodeId: "node",
+    agent: "oracle",
+    task: "Challenge the direction without modifying files.",
+    context: "fork",
+    cwd: process.cwd(),
+    result: { kind: "text" },
+  });
+  if (!parsed.ok) throw new Error(parsed.error);
+
+  const reviewer = await resolveSubagentLaunchContract({
+    agent: "reviewer",
+    cwd: process.cwd(),
+    task: "Review without modifying files.",
+    context: "fresh",
+  });
+  if (!reviewer.ok) throw new Error(reviewer.message);
+  assert.deepEqual(reviewer.contract.tools.effectiveAllowlist, [
+    "read",
+    "grep",
+    "find",
+    "ls",
+    "bash",
+    "intercom",
+  ]);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/configs/pi/.config/pi/agent/extensions/subagents-once/index.ts
+++ b/configs/pi/.config/pi/agent/extensions/subagents-once/index.ts
@@ -31,7 +31,6 @@ export type OnceState = { armed: boolean; callUsed: boolean };
 type Thinking = (typeof THINKING_LEVELS)[number];
 
 type DelegationIdentity = {
-  version: 2;
   requestId: string;
   ownerRunId: string;
   nodeId: string;
@@ -143,7 +142,6 @@ function matchesIdentity(
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const candidate = value as Partial<DelegationIdentity>;
   return (
-    candidate.version === identity.version &&
     candidate.requestId === identity.requestId &&
     candidate.ownerRunId === identity.ownerRunId &&
     candidate.nodeId === identity.nodeId
@@ -196,12 +194,11 @@ async function delegate(
     ctx.modelRegistry.find(provider, modelId),
   );
   const identity: DelegationIdentity = {
-    version: 2,
     requestId: randomUUID(),
     ownerRunId: ctx.sessionManager.getSessionId(),
     nodeId: toolCallId,
   };
-  const request: DelegationRequest = {
+  const request = {
     ...identity,
     agent: role,
     task: params.task,
@@ -210,7 +207,7 @@ async function delegate(
     ...(model ? { model } : {}),
     ...(params.thinking ? { thinking: params.thinking } : {}),
     result: { kind: "text" },
-  };
+  } satisfies DelegationRequest;
 
   let resolveResponse!: (response: DelegationResponse) => void;
   const responsePromise = new Promise<DelegationResponse>((resolve) => {
@@ -292,6 +289,13 @@ export function demo(): void {
     }
     if (!rejected) throw new Error(`model validation accepted ${model}`);
   }
+  const identity: DelegationIdentity = {
+    requestId: "request",
+    ownerRunId: "owner",
+    nodeId: "node",
+  };
+  if (!matchesIdentity({ ...identity, status: "completed" }, identity))
+    throw new Error("delegation identity matching failed");
   const state: OnceState = { armed: true, callUsed: false };
   if (consumeCall(state) !== undefined || !consumeCall(state))
     throw new Error("one-call policy failed");

--- a/configs/pi/.config/pi/agent/settings.json
+++ b/configs/pi/.config/pi/agent/settings.json
@@ -14,18 +14,13 @@
       "reviewer": {
         "model": "openai-codex/gpt-5.6-terra",
         "thinking": "medium",
-        "defaultContext": "fresh"
+        "defaultContext": "fresh",
+        "tools": ["read", "grep", "find", "ls", "bash", "intercom"]
       },
       "advisor": {
         "disabled": true
       },
-      "context-builder": {
-        "disabled": true
-      },
       "delegate": {
-        "disabled": true
-      },
-      "planner": {
         "disabled": true
       },
       "researcher": {


### PR DESCRIPTION
Repair `subagents-once` for the current structured owned-leaf delegation contract, add a contract regression check, and keep the reviewer advisory by removing its direct write tools. Also remove the obsolete session spawn cap and stale builtin overrides.
