### PR TITLE
fix(configs): pi respect dynamic tool state

### DIFF
--- a/configs/fish/.config/fish/functions/pi-update.fish
+++ b/configs/fish/.config/fish/functions/pi-update.fish
@@ -6,11 +6,10 @@ function pi-update --description "Update pi-agent and extensions"
     set -l extensions $PI_CODING_AGENT_DIR/extensions
 
     test -f $examples/handoff.ts
-    and test -f $examples/tools.ts
     and test -f $examples/plan-mode/index.ts
     or return 1
 
     mkdir -p $extensions
-    command rsync -a $examples/handoff.ts $examples/notify.ts $examples/tools.ts $extensions/
+    command rsync -a $examples/handoff.ts $examples/notify.ts $extensions/
     command rsync -a --delete $examples/plan-mode/ $extensions/plan-mode/
 end

--- a/configs/pi/.config/pi/agent/extensions/tools.ts
+++ b/configs/pi/.config/pi/agent/extensions/tools.ts
@@ -1,0 +1,146 @@
+/**
+ * Tools Extension
+ *
+ * Provides a /tools command to enable/disable tools interactively.
+ * Tool selection persists across session reloads and respects branch navigation.
+ *
+ * Usage:
+ * 1. Copy this file to ~/.pi/agent/extensions/ or your project's .pi/extensions/
+ * 2. Use /tools to open the tool selector
+ */
+
+import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
+import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
+import { Container, type SettingItem, SettingsList } from "@earendil-works/pi-tui";
+
+// State persisted to session
+interface ToolsState {
+	enabledTools: string[];
+}
+
+export default function toolsExtension(pi: ExtensionAPI) {
+	// Track enabled tools
+	let enabledTools: Set<string> = new Set();
+	let allTools: ToolInfo[] = [];
+
+	// Persist current state
+	function persistState() {
+		pi.appendEntry<ToolsState>("tools-config", {
+			enabledTools: Array.from(enabledTools),
+		});
+	}
+
+	// Apply current tool selection
+	function applyTools() {
+		pi.setActiveTools(Array.from(enabledTools));
+	}
+
+	// Find the last tools-config entry in the current branch
+	function restoreFromBranch(ctx: ExtensionContext) {
+		allTools = pi.getAllTools();
+
+		// Get entries in current branch only
+		const branchEntries = ctx.sessionManager.getBranch();
+		let savedTools: string[] | undefined;
+
+		for (const entry of branchEntries) {
+			if (entry.type === "custom" && entry.customType === "tools-config") {
+				const data = entry.data as ToolsState | undefined;
+				if (data?.enabledTools) {
+					savedTools = data.enabledTools;
+				}
+			}
+		}
+
+		if (savedTools) {
+			// Restore saved tool selection (filter to only tools that still exist)
+			const allToolNames = allTools.map((t) => t.name);
+			enabledTools = new Set(savedTools.filter((t: string) => allToolNames.includes(t)));
+			applyTools();
+		} else {
+			// No saved state - sync with currently active tools
+			enabledTools = new Set(pi.getActiveTools());
+		}
+	}
+
+	// Register /tools command
+	pi.registerCommand("tools", {
+		description: "Enable/disable tools",
+		handler: async (_args, ctx) => {
+			if (ctx.mode !== "tui") {
+				ctx.ui.notify("/tools requires TUI mode", "error");
+				return;
+			}
+
+			// Refresh tool list
+			allTools = pi.getAllTools();
+
+			await ctx.ui.custom((tui, theme, _kb, done) => {
+				// Build settings items for each tool
+				const items: SettingItem[] = allTools.map((tool) => ({
+					id: tool.name,
+					label: tool.name,
+					currentValue: enabledTools.has(tool.name) ? "enabled" : "disabled",
+					values: ["enabled", "disabled"],
+				}));
+
+				const container = new Container();
+				container.addChild(
+					new (class {
+						render(_width: number) {
+							return [theme.fg("accent", theme.bold("Tool Configuration")), ""];
+						}
+						invalidate() {}
+					})(),
+				);
+
+				const settingsList = new SettingsList(
+					items,
+					Math.min(items.length + 2, 15),
+					getSettingsListTheme(),
+					(id, newValue) => {
+						// Update enabled state and apply immediately
+						if (newValue === "enabled") {
+							enabledTools.add(id);
+						} else {
+							enabledTools.delete(id);
+						}
+						applyTools();
+						persistState();
+					},
+					() => {
+						// Close dialog
+						done(undefined);
+					},
+				);
+
+				container.addChild(settingsList);
+
+				const component = {
+					render(width: number) {
+						return container.render(width);
+					},
+					invalidate() {
+						container.invalidate();
+					},
+					handleInput(data: string) {
+						settingsList.handleInput?.(data);
+						tui.requestRender();
+					},
+				};
+
+				return component;
+			});
+		},
+	});
+
+	// Restore state on session start
+	pi.on("session_start", async (_event, ctx) => {
+		restoreFromBranch(ctx);
+	});
+
+	// Restore state when navigating the session tree
+	pi.on("session_tree", async (_event, ctx) => {
+		restoreFromBranch(ctx);
+	});
+}

--- a/configs/pi/.config/pi/agent/extensions/tools.ts
+++ b/configs/pi/.config/pi/agent/extensions/tools.ts
@@ -67,6 +67,8 @@ export default function toolsExtension(pi: ExtensionAPI) {
 	pi.registerCommand("tools", {
 		description: "Enable/disable tools",
 		handler: async (_args, ctx) => {
+			enabledTools = new Set(pi.getActiveTools());
+
 			if (ctx.mode !== "tui") {
 				ctx.ui.notify("/tools requires TUI mode", "error");
 				return;

--- a/configs/pi/.config/pi/agent/extensions/with-agents/README.md
+++ b/configs/pi/.config/pi/agent/extensions/with-agents/README.md
@@ -33,6 +33,10 @@ A later `/with-agents` can use `get_subagent_result`, `steer_subagent`, or
 `Agent({ resume: "..." })` with agent IDs that Tintinweb still holds in its
 manager.
 
+`/tools` remains an explicit manual override. Enabling orchestration tools there
+makes them available without arming or validator instructions until the user
+turns them off or a new session restores the default hidden state.
+
 ## Policy
 
 The parent silently evaluates three gates before every `Agent` call. If any

--- a/configs/pi/.config/pi/agent/extensions/with-agents/index.ts
+++ b/configs/pi/.config/pi/agent/extensions/with-agents/index.ts
@@ -90,12 +90,6 @@ export default function subagentsOnce(pi: ExtensionAPI) {
     return { systemPrompt: `${event.systemPrompt}\n\n${validatorPrompt}` };
   });
 
-  pi.on("tool_call", (event) => {
-    if (ORCHESTRATION_TOOL_SET.has(event.toolName) && state.phase !== "active") {
-      return { block: true, reason: "Run /with-agents before using subagent tools." };
-    }
-  });
-
   pi.on("agent_settled", () => {
     if (settleParentRun(state)) hideTools();
   });


### PR DESCRIPTION
Maintain `/tools` locally so it reflects runtime activation changes, and stop overwriting it from Pi examples during `pi-update`. Agent tools remain hidden by default, while an explicit `/tools` selection is respected as a manual override outside `/with-agents`.
