### PR TITLE
fix(configs): pi keep agents through notifications

### DIFF
--- a/configs/pi/.config/pi/agent/extensions/with-agents/README.md
+++ b/configs/pi/.config/pi/agent/extensions/with-agents/README.md
@@ -25,10 +25,15 @@ starts, all three orchestration tools become active and the parent receives the
 validator policy. The parent may make zero, one, or several `Agent` calls.
 Independent sibling calls can run in parallel.
 
-After the parent run reaches `agent_settled`, the orchestration tools are hidden
-again. Background agents are not stopped: Tintinweb continues running them and
-shows its `● Agents` widget. The widget includes foreground and background
-agents, while the below-editor FleetView is disabled globally.
+If the parent run reaches `agent_settled` with no background agents, the
+orchestration tools are hidden again. Otherwise they stay active while those
+agents run and while Tintinweb delivers their completion notifications. They
+are hidden after every tracked background result has been delivered or consumed
+and the resulting parent run reaches `agent_settled`.
+
+Tintinweb shows running agents in its `● Agents` widget. The widget includes
+foreground and background agents, while the below-editor FleetView is disabled
+globally.
 
 A later `/with-agents` can use `get_subagent_result`, `steer_subagent`, or
 `Agent({ resume: "..." })` with agent IDs that Tintinweb still holds in its
@@ -187,6 +192,8 @@ Manual smoke test:
    `steer_subagent` are available during that run.
 4. Start several independent background agents and confirm no more than four
    run concurrently and Tintinweb renders their standard UI.
-5. Let the parent settle and confirm the tools disappear while background
-   agents continue.
-6. Arm again and resume or query an agent whose ID is still in manager memory.
+5. Let the initial parent run settle while background agents continue and
+   confirm all three tools remain active.
+6. Let the completion notifications finish and confirm the tools disappear
+   after the final resulting run settles.
+7. Arm again and resume or query an agent whose ID is still in manager memory.

--- a/configs/pi/.config/pi/agent/extensions/with-agents/contract-test.ts
+++ b/configs/pi/.config/pi/agent/extensions/with-agents/contract-test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 
 import {
   arm,
+  completeBackgroundAgent,
+  consumeBackgroundNotification,
+  consumeBackgroundResult,
   createState,
   formatContextUsage,
+  noteBackgroundAgent,
   noteUserPrompt,
   reset,
   settleParentRun,
@@ -21,6 +25,26 @@ assert.equal(noteUserPrompt(state, "interactive"), true);
 assert.equal(startParentRun(state), true);
 assert.equal(state.phase, "active");
 assert.equal(noteUserPrompt(state, "interactive"), false);
+assert.equal(settleParentRun(state), true);
+assert.deepEqual(state, createState());
+
+assert.equal(arm(state), true);
+assert.equal(noteUserPrompt(state, "interactive"), true);
+assert.equal(startParentRun(state), true);
+assert.equal(noteBackgroundAgent(state, "background-1"), true);
+assert.equal(settleParentRun(state), false);
+assert.equal(completeBackgroundAgent(state, "background-1"), true);
+assert.equal(settleParentRun(state), false);
+assert.equal(consumeBackgroundNotification(state, ["background-1"]), true);
+assert.equal(settleParentRun(state), true);
+assert.deepEqual(state, createState());
+
+assert.equal(arm(state), true);
+assert.equal(noteUserPrompt(state, "interactive"), true);
+assert.equal(startParentRun(state), true);
+assert.equal(noteBackgroundAgent(state, "background-2"), true);
+assert.equal(completeBackgroundAgent(state, "background-2"), true);
+assert.equal(consumeBackgroundResult(state, "background-2"), true);
 assert.equal(settleParentRun(state), true);
 assert.deepEqual(state, createState());
 

--- a/configs/pi/.config/pi/agent/extensions/with-agents/index.ts
+++ b/configs/pi/.config/pi/agent/extensions/with-agents/index.ts
@@ -2,8 +2,12 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import {
   arm,
+  completeBackgroundAgent,
+  consumeBackgroundNotification,
+  consumeBackgroundResult,
   createState,
   formatContextUsage,
+  noteBackgroundAgent,
   noteUserPrompt,
   reset,
   settleParentRun,
@@ -78,6 +82,38 @@ export default function subagentsOnce(pi: ExtensionAPI) {
 
   pi.on("input", (event) => {
     if (noteUserPrompt(state, event.source)) showTools();
+  });
+
+  pi.on("tool_result", (event) => {
+    if (event.toolName === "Agent") {
+      const details = event.details as { status?: string; agentId?: string } | undefined;
+      if (details?.status === "background" && details.agentId) {
+        noteBackgroundAgent(state, details.agentId);
+      }
+    } else if (event.toolName === "get_subagent_result") {
+      const input = event.input as { agent_id?: string };
+      if (input.agent_id) consumeBackgroundResult(state, input.agent_id);
+    }
+  });
+
+  for (const eventName of ["subagents:completed", "subagents:failed"]) {
+    pi.events.on(eventName, (data) => {
+      const id = (data as { id?: string }).id;
+      if (id) completeBackgroundAgent(state, id);
+    });
+  }
+
+  pi.on("message_start", (event) => {
+    if (event.message.role !== "custom" || event.message.customType !== "subagent-notification") {
+      return;
+    }
+    const details = event.message.details as
+      | { id?: string; others?: Array<{ id?: string }> }
+      | undefined;
+    const ids = [details?.id, ...(details?.others?.map(({ id }) => id) ?? [])].filter(
+      (id): id is string => Boolean(id),
+    );
+    consumeBackgroundNotification(state, ids);
   });
 
   pi.on("before_agent_start", (event, ctx) => {

--- a/configs/pi/.config/pi/agent/extensions/with-agents/policy.ts
+++ b/configs/pi/.config/pi/agent/extensions/with-agents/policy.ts
@@ -1,6 +1,7 @@
 export type OnceState = {
   phase: "disabled" | "armed" | "active";
   pendingUserPrompt: boolean;
+  backgroundAgents: Map<string, "running" | "completed">;
 };
 
 export type ContextUsage = {
@@ -10,7 +11,7 @@ export type ContextUsage = {
 };
 
 export function createState(): OnceState {
-  return { phase: "disabled", pendingUserPrompt: false };
+  return { phase: "disabled", pendingUserPrompt: false, backgroundAgents: new Map() };
 }
 
 export function arm(state: OnceState): boolean {
@@ -32,8 +33,29 @@ export function startParentRun(state: OnceState): boolean {
   return true;
 }
 
-export function settleParentRun(state: OnceState): boolean {
+export function noteBackgroundAgent(state: OnceState, id: string): boolean {
   if (state.phase !== "active") return false;
+  state.backgroundAgents.set(id, "running");
+  return true;
+}
+
+export function completeBackgroundAgent(state: OnceState, id: string): boolean {
+  if (!state.backgroundAgents.has(id)) return false;
+  state.backgroundAgents.set(id, "completed");
+  return true;
+}
+
+export function consumeBackgroundNotification(state: OnceState, ids: string[]): boolean {
+  return ids.reduce((consumed, id) => state.backgroundAgents.delete(id) || consumed, false);
+}
+
+export function consumeBackgroundResult(state: OnceState, id: string): boolean {
+  if (state.backgroundAgents.get(id) !== "completed") return false;
+  return state.backgroundAgents.delete(id);
+}
+
+export function settleParentRun(state: OnceState): boolean {
+  if (state.phase !== "active" || state.backgroundAgents.size > 0) return false;
   reset(state);
   return true;
 }
@@ -41,6 +63,7 @@ export function settleParentRun(state: OnceState): boolean {
 export function reset(state: OnceState): void {
   state.phase = "disabled";
   state.pendingUserPrompt = false;
+  state.backgroundAgents.clear();
 }
 
 export function formatContextUsage(usage: ContextUsage | undefined): string | undefined {


### PR DESCRIPTION
Keep orchestration tools active while background subagents and their completion notifications remain part of the current with-agents operation. Results consumed through notifications or get_subagent_result now close the operation, with contract coverage for both paths.
