### PR TITLE
style(configs): tmux use theme dim color

### DIFF
--- a/configs/tmux/.tmux.conf
+++ b/configs/tmux/.tmux.conf
@@ -85,7 +85,7 @@ set -g status-interval 1
 set -g status-left-length 40
 set -g status-right '#{cpu_fg_color}#{cpu_icon} #{cpu_percentage}#[default] #{prefix_highlight}'
 set -g status-right-length 40
-set -g status-style bg='default',fg='colour59'
+set -g status-style bg='default',fg='colour8'
 
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-cpu'


### PR DESCRIPTION
## Summary

- use Koda palette color 8 for the tmux status line
- keep the status color synchronized with light and dark terminal themes

## Validation

- reloaded the live tmux configuration
- confirmed `status-style=bg=default,fg=colour8`
- repository formatting hook passed
