### PR TITLE
feat: add Claude Code setup

### DIFF
--- a/configs/claude/.claude/settings.json
+++ b/configs/claude/.claude/settings.json
@@ -1,0 +1,133 @@
+{
+  "permissions": {
+    "defaultMode": "bypassPermissions"
+  },
+  "model": "opus[1m]",
+  "statusLine": {
+    "type": "command",
+    "command": "sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud-cache.sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs"
+  },
+  "enabledPlugins": {
+    "claude-code-wakatime@wakatime": true,
+    "shopify-plugin@shopify-ai-toolkit": true,
+    "oh-my-claudecode@omc": true,
+    "shopify@slavafyi": true,
+    "common@slavafyi": true,
+    "forge@slavafyi": true,
+    "harden@slavafyi": true
+  },
+  "extraKnownMarketplaces": {
+    "wakatime": {
+      "source": {
+        "source": "github",
+        "repo": "wakatime/claude-code-wakatime"
+      }
+    },
+    "slavafyi": {
+      "source": {
+        "source": "github",
+        "repo": "slavafyi/skills"
+      }
+    },
+    "shopify-ai-toolkit": {
+      "source": {
+        "source": "github",
+        "repo": "Shopify/shopify-ai-toolkit"
+      }
+    },
+    "omc": {
+      "source": {
+        "source": "github",
+        "repo": "Yeachan-Heo/oh-my-claudecode"
+      }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  },
+  "effortLevel": "xhigh",
+  "tui": "default",
+  "skipDangerousModePermissionPrompt": true,
+  "theme": "auto",
+  "editorMode": "normal",
+  "preferredNotifChannel": "auto",
+  "autoCompactEnabled": true,
+  "switchModelsOnFlag": false,
+  "remoteControlAtStartup": true,
+  "omcHud": {
+    "preset": "minimal",
+    "elements": {
+      "omcLabel": false,
+      "updateNotification": true,
+      "model": true,
+      "modelFormat": "versioned",
+      "rateLimits": true,
+      "cwd": false,
+      "gitRepo": false,
+      "gitBranch": true,
+      "gitStatus": false,
+      "gitInfoPosition": "below",
+      "contextBar": true,
+      "useBars": false,
+      "agents": true,
+      "agentsFormat": "multiline",
+      "agentsMaxLines": 3,
+      "ralph": true,
+      "autopilot": true,
+      "prdStory": true,
+      "activeSkills": false,
+      "lastSkill": false,
+      "backgroundTasks": true,
+      "todos": true,
+      "thinking": true,
+      "thinkingFormat": "text",
+      "promptTime": true,
+      "sessionHealth": false,
+      "showSessionDuration": false,
+      "showHealthIndicator": false,
+      "showCallCounts": false,
+      "profile": false,
+      "showTokens": false,
+      "hostname": false,
+      "apiKeySource": false,
+      "permissionStatus": false,
+      "missionBoard": false,
+      "sessionSummary": false,
+      "showLastTool": false,
+      "maxOutputLines": 6,
+      "safeMode": true
+    },
+    "layout": {
+      "line1": [
+        "ralph",
+        "autopilot",
+        "prd",
+        "agents",
+        "background",
+        "promptTime"
+      ],
+      "main": [
+        "gitBranch",
+        "model",
+        "contextBar",
+        "rateLimits",
+        "thinking"
+      ],
+      "detail": [
+        "agents",
+        "contextWarning",
+        "payloadWarning",
+        "todos"
+      ]
+    },
+    "thresholds": {
+      "contextWarning": 70,
+      "contextCompactSuggestion": 80,
+      "contextCritical": 85
+    },
+    "wrapMode": "truncate"
+  }
+}

--- a/configs/claude/.config/claude-omc/config.jsonc
+++ b/configs/claude/.config/claude-omc/config.jsonc
@@ -1,0 +1,66 @@
+{
+  "agents": {
+    // Deep reasoning
+    "analyst": {
+      "model": "fable"
+    },
+    "planner": {
+      "model": "fable"
+    },
+    "architect": {
+      "model": "fable"
+    },
+    "critic": {
+      "model": "fable"
+    },
+    "securityReviewer": {
+      "model": "fable"
+    },
+
+    // Coding / execution
+    "executor": {
+      "model": "opus"
+    },
+    "debugger": {
+      "model": "opus"
+    },
+    "tracer": {
+      "model": "opus"
+    },
+    "verifier": {
+      "model": "opus"
+    },
+    "testEngineer": {
+      "model": "opus"
+    },
+    "qaTester": {
+      "model": "opus"
+    },
+    "codeReviewer": {
+      "model": "opus"
+    },
+    "codeSimplifier": {
+      "model": "opus"
+    },
+
+    // Supporting roles
+    "explore": {
+      "model": "sonnet"
+    },
+    "designer": {
+      "model": "opus"
+    },
+    "documentSpecialist": {
+      "model": "opus"
+    },
+    "gitMaster": {
+      "model": "sonnet"
+    },
+    "scientist": {
+      "model": "opus"
+    },
+    "writer": {
+      "model": "sonnet"
+    }
+  }
+}

--- a/configs/claude/.config/claude-omc/config.jsonc
+++ b/configs/claude/.config/claude-omc/config.jsonc
@@ -11,7 +11,7 @@
       "model": "fable"
     },
     "critic": {
-      "model": "fable"
+      "model": "opus"
     },
     "securityReviewer": {
       "model": "fable"

--- a/scripts/arch/dev-tools.sh
+++ b/scripts/arch/dev-tools.sh
@@ -69,6 +69,19 @@ setup_opencode() {
   print_in_green "✓ OpenCode set up successfully!"
 }
 
+setup_claude() {
+  print_in_purple "Setting up Claude Code..."
+  sleep 2
+  pnpm install -g @anthropic-ai/claude-code@latest
+  stow \
+    --verbose \
+    --no-folding \
+    --dir "$DIR/configs" \
+    --target "$HOME" \
+    --stow claude
+  print_in_green "✓ Claude Code set up successfully!"
+}
+
 setup_pi() {
   print_in_purple "Setting up Pi coding agent..."
   sleep 2
@@ -137,6 +150,7 @@ dev_tools() {
   setup_neovim
   setup_tmux
   setup_opencode
+  setup_claude
   setup_pi
   setup_agents
   setup_bins

--- a/scripts/fedora/dev-tools.sh
+++ b/scripts/fedora/dev-tools.sh
@@ -82,6 +82,19 @@ setup_opencode() {
   print_in_green "✓ OpenCode set up successfully!"
 }
 
+setup_claude() {
+  print_in_purple "Setting up Claude Code..."
+  sleep 2
+  pnpm install -g @anthropic-ai/claude-code@latest
+  stow \
+    --verbose \
+    --no-folding \
+    --dir "$DIR/configs" \
+    --target "$HOME" \
+    --stow claude
+  print_in_green "✓ Claude Code set up successfully!"
+}
+
 setup_pi() {
   print_in_purple "Setting up Pi coding agent..."
   sleep 2
@@ -154,6 +167,7 @@ dev_tools() {
   setup_neovim
   setup_tmux
   setup_opencode
+  setup_claude
   setup_pi
   setup_agents
   setup_bins

--- a/scripts/macos/dev-tools.sh
+++ b/scripts/macos/dev-tools.sh
@@ -68,6 +68,19 @@ setup_opencode() {
   print_in_green "✓ OpenCode set up successfully!"
 }
 
+setup_claude() {
+  print_in_purple "Setting up Claude Code..."
+  sleep 2
+  pnpm install -g @anthropic-ai/claude-code@latest
+  stow \
+    --verbose \
+    --no-folding \
+    --dir "$DIR/configs" \
+    --target "$HOME" \
+    --stow claude
+  print_in_green "✓ Claude Code set up successfully!"
+}
+
 setup_pi() {
   print_in_purple "Setting up Pi coding agent..."
   sleep 2
@@ -136,6 +149,7 @@ dev_tools() {
   setup_neovim
   setup_tmux
   setup_opencode
+  setup_claude
   setup_pi
   setup_agents
   setup_bins


### PR DESCRIPTION
## Summary

- add a Stow package for Claude Code and OMC settings
- add `setup_claude` for macOS, Arch, and Fedora
- install the latest Claude Code package through pnpm

## Validation

- `bash -n scripts/{macos,arch,fedora}/dev-tools.sh`
- `shfmt --diff scripts/{macos,arch,fedora}/dev-tools.sh`
- `stow --simulate --verbose --no-folding --dir "$PWD/configs" --target "$HOME" --restow claude`
- verified both managed files resolve to the new Stow package
